### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 ## Overview
 This project implements the Model Context Protocol (MCP) as a practical embodiment of the Personal Intelligence Framework (PIF). Through structured tools and progressive interaction patterns, it creates spaces for meaningful development of understanding between humans and AI.
 
+<a href="https://glama.ai/mcp/servers/fr71fvl2at">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/fr71fvl2at/badge" alt="MCP-PIF Server MCP server" />
+</a>
+
 ## Quick Start
 
 ### Prerequisites


### PR DESCRIPTION
This PR adds a badge for the [MCP-PIF Server](https://glama.ai/mcp/servers/fr71fvl2at) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/fr71fvl2at">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/fr71fvl2at/badge" alt="MCP-PIF Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.